### PR TITLE
Eliminate a coercion to tibble

### DIFF
--- a/R/method-ts.r
+++ b/R/method-ts.r
@@ -35,8 +35,7 @@ null_ts <- function(var, modelfn) {
     model_fit <- ts %>%
       modelfn
     x <- simulate(model_fit, future=FALSE)
-    x <- as_data_frame(x)
-    df[[var]] <- as.vector(x$x)
+    df[[var]] <- as.vector(x)
     df
   }
 }


### PR DESCRIPTION
I'm helping @krlmlr to assess the potential impact of changes in dev tibble. I selected this package as one of the experiments.

There is an example in this package that fails with dev tibble:

https://github.com/krlmlr/tibble/blob/f-revdep-2/revdep/new-problems.md#nullabor

This PR fixes that and would make this package work with current CRAN tibble and the coming tibble release.

I'm no expert in time series, so you should sanity check what I've done, but this seems like a good simplification. It doesn't seem necessary to coerce the object to a tibble and then to a vector. If you can eliminate coercing to a tibble, then we don't have to deal with the fact that the variable has no name.