### PR TITLE
Fix bootstrap residuals and add permutation residuals

### DIFF
--- a/R/method-model.r
+++ b/R/method-model.r
@@ -6,8 +6,9 @@
 #'
 #' @param f model specification formula, as defined by \code{\link{lm}}
 #' @param method method for generating null residuals.  Built in methods
-#'   'rotate', 'pboot' and 'boot' are defined by \code{\link{resid_rotate}},
-#'   \code{\link{resid_pboot}} and \code{\link{resid_boot}} respectively
+#'   'rotate', 'perm', 'pboot' and 'boot' are defined by \code{\link{resid_rotate}},
+#'   \code{\link{resid_perm}}, \code{\link{resid_pboot}} and \code{\link{resid_boot}}
+#'   respectively
 #' @param ... other arguments passedd onto \code{method}.
 #' @return a function that given \code{data} generates a null data set.
 #'   For use with \code{\link{lineup}} or \code{\link{rorschach}}
@@ -93,5 +94,16 @@ resid_sigma <- function(model, data, sigma = 1) {
 #' @importFrom stats resid
 #' @export
 resid_boot <- function(model, data) {
+    sample(stats::resid(model), replace = TRUE)
+}
+
+#' Permutation residuals.
+#'
+#' For use with \code{\link{null_lm}}
+#'
+#' @param model to extract residuals from
+#' @importFrom stats resid
+#' @export
+resid_perm <- function(model, data) {
     sample(stats::resid(model))
 }


### PR DESCRIPTION
Currently, the bootstrap residuals method for `null_lm` computes permutation residuals instead of bootstrap residuals (nonparametric bootstrapping being resampling with replacement, at least in this case). This PR:

- Modifies `resid_boot` to compute bootstrap residuals.
- Adds `resid_perm` to allow users to compute permutation residuals.

Closes #21