### PR TITLE
Fix bug in QQ-plots created using lineup_residuals()

### DIFF
--- a/R/quick_plots.R
+++ b/R/quick_plots.R
@@ -98,7 +98,7 @@ lineup_residuals <- function(model, type = 1, method = "rotate", color_points = 
   if(type == 2) {
     if(method != "pboot") { warning(paste0("Method \"", method, "\" does not generate normal residuals. Using method = \"pboot\" instead."))}
     p <- ggplot(lineup(null_lm(formula(model), method = "pboot", additional = TRUE), model.reg)) +
-          geom_qq_line(aes(sample = .data$.resid), colour = color_lines) +
+          geom_qq_line(aes(sample = .data$.stdresid), colour = color_lines) +
           geom_qq(aes(sample = .data$.stdresid), alpha = alpha_points, color = color_points) +
           facet_wrap(~ .data$.sample) +
           labs(x = "Theoretical quantiles", y = "Standardized residuals", title = "Normal Q-Q plot")


### PR DESCRIPTION
One of the geoms used to create QQ-plots in `lineup_residuals()` used raw residuals instead of standardized residuals, causing erroneous figures for some models. This PR fixes this bug.

Output before fix:
![image](https://github.com/user-attachments/assets/eb1ce12a-e880-4273-b0c3-3f86d52632f4)

Output after fix:
![image](https://github.com/user-attachments/assets/18282ce5-cd36-4c48-bbca-e098a0439933)
